### PR TITLE
Update advanced-logger.js in order to comply with Winston configuration

### DIFF
--- a/advance-logger.js
+++ b/advance-logger.js
@@ -8,7 +8,7 @@ module.exports = function (RED) {
         winston.handleExceptions(new winston.transports.File({ filename: 'exceptions.log' }));
         RED.nodes.createNode(this, config);
         var node = this;
-        var filesize = 1073741824;
+        var filesize = 1048576;
         var maxfiles = 1;
         var archive = false;
         var logType = config.logtype;
@@ -19,7 +19,7 @@ module.exports = function (RED) {
         var logger = null;        
 
         if (config.maxsize >= 1) {
-            filesize = config.maxsize * 1073741824;
+            filesize = config.maxsize * 1048576;
         }
         if (config.maxFiles >= 1) {
             maxfiles = config.maxFiles;


### PR DESCRIPTION
It seems that you have an error in the configuration of the logger. As a matter of fact, if a configure the logger to have a max size of 1mb you should configure the winston.logger maxsize variable in this way filesize = config.maxsize * 1048576 and not filesize = config.maxsize * 1073741824 (since it is 1000 Mb).